### PR TITLE
Make dragged box stay in dropped area

### DIFF
--- a/Chapter09/Exercise9.09/hello-drag-and-drop/src/hello_drag_and_drop/core.cljs
+++ b/Chapter09/Exercise9.09/hello-drag-and-drop/src/hello_drag_and_drop/core.cljs
@@ -55,6 +55,7 @@
            (println "Dropping element with id" draggable-id)
            (reset! is-element-dropped? true)
            (.draggable (.-draggable ui) "disable")
+           (.draggable (.-draggable ui) (attrs {:revert false}))
            (.droppable ($ (str "#" (.-id (.-target event)))) "disable")
            (.position (.-draggable ui)
                       (attrs {:of ($ (str "#" (.-id (.-target event)))) :my "left top" :at "left top"}))))


### PR DESCRIPTION
Hi,

Commit https://github.com/PacktWorkshops/The-Clojure-Workshop/commit/c8df2a986b937502091c98d442a6b5046fe096f5#diff-7aa432bb2a3ec8ed060bb6d6121ff46bL57 broke the drop functionality. This PR restores makes dropping work again.

Before:
![before](https://user-images.githubusercontent.com/5002921/73567256-4a2c6d80-4466-11ea-9bed-c16ab6a161d0.gif)

After:
![after](https://user-images.githubusercontent.com/5002921/73567267-51ec1200-4466-11ea-8023-c6df88933446.gif)

So that readers that try the code have working functionality, could this be merged or in another way fixed?

Kind regards,
Erwin