### PR TITLE
Changes to code based on customer inquiries

### DIFF
--- a/Chapter04/Activity4.01/src/packt-clj/game_values.clj
+++ b/Chapter04/Activity4.01/src/packt-clj/game_values.clj
@@ -1,6 +1,5 @@
 (ns packt-clj.game-values)
 
-
 (def game-users
   [{:id 9342
     :username "speedy"
@@ -63,22 +62,19 @@
     :experience-level 8
     :status :active}])
 
-
 (defn max-value-by-status [field status users]
-               (->> 
-                 users
-                  ;; step 1: use filter to only keep users who
-                  ;; have the status we are looking for 
-                 (filter #(= (:status %) status))
-                 ;; step 2: field is a keyword, so we can use it as 
-                 ;; a function when calling map.
-                 (map field)
-                 ;; step 3: use the apply max pattern, with a default
-                 (apply max 0)))
+  (->> users
+       ;; step 1: use filter to only keep users who
+       ;; have the status we are looking for
+       (filter #(= (:status %) status))
+       ;; step 2: field is a keyword, so we can use it as
+       ;; a function when calling map.
+       (map field)
+       ;; step 3: use the apply max pattern, with a default
+       (apply max 0)))
 
 (defn min-value-by-status [field status users]
-               (->> 
-                 users
-                 (filter #(= (:status %) status))
-                 (map field)
-                 (apply min 0)))
+  (->> users
+       (filter #(= (:status %) status))
+       (map field)
+       (apply min))) ;; do not use a default, (min '()) returns nil

--- a/Chapter04/Activity4.01/src/packt-clj/game_values.clj
+++ b/Chapter04/Activity4.01/src/packt-clj/game_values.clj
@@ -77,4 +77,4 @@
   (->> users
        (filter #(= (:status %) status))
        (map field)
-       (apply min))) ;; do not use a default, (min '()) returns nil
+       (apply min)))

--- a/Chapter06/Exercise6.07/train_routes.clj
+++ b/Chapter06/Exercise6.07/train_routes.clj
@@ -55,7 +55,7 @@
       (= position destination) path
 
       (get-in route-lookup [position destination])
-      (conj path destination)
+      [(conj path destination)]
 
       :otherwise-we-search
       (let [path-set (set path)


### PR DESCRIPTION
Dear maintainer,

Based on inquiries I changed some code. I think it's now more correct. Let me know if there are any questions.

Kind regards,
Erwin

---

### Activity 4.01:
Align and do not use default with `apply min`
Since `(apply min <any-coll> 0)` is always 0

### Exercise 6.07:
There's a bug in the code for direct routes that are not over multiple hops.
min-route expects a collection so we should always return a collection.

This way it works for both direct and indirect routes:
```
(find-path (grouped-routes routes) :paris :london)
;; => {:cost 236, :best [:paris :london]}
(find-path (grouped-routes routes) :paris :budapest)
;; => {:cost 251, :best [:paris :milan :vienna :budapest]}
```