### PR TITLE
Use plain ASCII insted of Unicode

### DIFF
--- a/Chapter01/Exercise1.07/repl.clj
+++ b/Chapter01/Exercise1.07/repl.clj
@@ -11,7 +11,7 @@
 (= false nil)
 (= "hello" "hello" (clojure.string/reverse "olleh"))
 (= [1 2 3] [1 2 3])
-(= ‘(1 2 3) [1 2 3])
+(= '(1 2 3) [1 2 3])
 (= 1)
 (= "I will not reason and compare: my business is to create.")
 
@@ -47,7 +47,7 @@
 ; }
 ;;  Javascript code example 2:
 ; let x = 50;
-; console.log(x >= 0 && x <= 100 || x % 100 == 0 ? "Valid" : “Invalid");
+; console.log(x >= 0 && x <= 100 || x % 100 == 0 ? "Valid" : "Invalid");
 
 (let [x 50]
   (if (or (<= 1 x 100) (= 0 (mod x 100)))


### PR DESCRIPTION
Fixes the following errors:

Line 14:
Unable to resolve symbol: ‘ in this context

Javascript code example 2 at line 50:
SyntaxError: Invalid character '\u201c'
